### PR TITLE
Improve contract macro diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update `syn` requirement to `3`.
 - Minimum supported Rust version (MSRV) is now 1.77.
 - Reject contract predicates that are the literal `false` at compile time.
+- Improve diagnostics for invalid contract attributes.
 
 ## 0.6.7
 

--- a/src/implementation/ensures.rs
+++ b/src/implementation/ensures.rs
@@ -4,12 +4,15 @@
 
 use proc_macro2::TokenStream;
 
-use crate::implementation::{ContractMode, ContractType, FuncWithContracts};
+use crate::implementation::{emit_error, ContractMode, ContractType, FuncWithContracts};
 
 pub(crate) fn ensures(mode: ContractMode, attr: TokenStream, toks: TokenStream) -> TokenStream {
     let ty = ContractType::Ensures;
 
-    let func = syn::parse_quote!(#toks);
+    let func = match syn::parse2(toks.clone()) {
+        Ok(func) => func,
+        Err(err) => return emit_error(err, toks),
+    };
 
     let f = FuncWithContracts::new_with_initial_contract(func, ty, mode, attr);
 

--- a/src/implementation/invariant.rs
+++ b/src/implementation/invariant.rs
@@ -6,20 +6,30 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{FnArg, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl};
 
-use crate::implementation::{ContractMode, ContractType, FuncWithContracts};
+use crate::implementation::{emit_error, ContractMode, ContractType, FuncWithContracts};
 
 pub(crate) fn invariant(mode: ContractMode, attr: TokenStream, toks: TokenStream) -> TokenStream {
-    let item: Item = syn::parse_quote!(#toks);
-
     let name = mode.name().unwrap().to_string() + "invariant";
+
+    let item: Item = match syn::parse2(toks.clone()) {
+        Ok(item) => item,
+        Err(err) => return emit_error(err, toks),
+    };
 
     match item {
         Item::Fn(fn_) => invariant_fn(mode, attr, fn_),
         Item::Impl(impl_) => invariant_impl(mode, attr, impl_),
-        _ => unimplemented!(
-            "The #[{}] attribute only works on functions and impl-blocks.",
-            name
-        ),
+        item => {
+            let error = syn::Error::new_spanned(
+                &item,
+                format!(
+                    "the #[{}] attribute only works on functions and impl blocks",
+                    name
+                ),
+            );
+
+            emit_error(error, item)
+        }
     }
 }
 

--- a/src/implementation/mod.rs
+++ b/src/implementation/mod.rs
@@ -18,6 +18,14 @@ pub(crate) use requires::requires;
 use syn::{Expr, ItemFn};
 pub(crate) use traits::{contract_trait_item_impl, contract_trait_item_trait};
 
+pub(crate) fn emit_error(err: syn::Error, tokens: impl ToTokens) -> TokenStream {
+    let error = err.into_compile_error();
+    quote::quote! {
+        #error
+        #tokens
+    }
+}
+
 /// Checking-mode of a contract.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum ContractMode {

--- a/src/implementation/parse.rs
+++ b/src/implementation/parse.rs
@@ -19,23 +19,25 @@ pub(crate) fn parse_attributes(
 
     let mut conds: Vec<Expr> = vec![];
 
-    for seg in rewritten_segs {
+    let last_segment_idx = rewritten_segs.len().saturating_sub(1);
+
+    for (idx, seg) in rewritten_segs.into_iter().enumerate() {
         let expr = match syn::parse2::<Expr>(seg) {
             Ok(val) => val,
             Err(err) => Expr::Verbatim(err.to_compile_error()),
         };
+
+        if idx != last_segment_idx && string_lit_value(&expr).is_some() {
+            let err =
+                syn::Error::new_spanned(expr, "contract description must be the last argument");
+            conds.push(Expr::Verbatim(err.to_compile_error()));
+            continue;
+        }
+
         conds.push(expr);
     }
 
-    let desc = conds
-        .last()
-        .map(|expr| match expr {
-            Expr::Lit(ExprLit {
-                lit: Lit::Str(str), ..
-            }) => Some(str.value()),
-            _ => None,
-        })
-        .unwrap_or(None);
+    let desc = conds.last().and_then(string_lit_value);
 
     if desc.is_some() {
         conds.pop();
@@ -47,6 +49,15 @@ pub(crate) fn parse_attributes(
     }
 
     (conds, segments_stream, desc)
+}
+
+fn string_lit_value(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(str), ..
+        }) => Some(str.value()),
+        _ => None,
+    }
 }
 
 fn error_on_false_literal(expr: &mut Expr) {

--- a/src/implementation/requires.rs
+++ b/src/implementation/requires.rs
@@ -5,12 +5,15 @@
 use proc_macro2::TokenStream;
 use syn::ItemFn;
 
-use crate::implementation::{ContractMode, ContractType, FuncWithContracts};
+use crate::implementation::{emit_error, ContractMode, ContractType, FuncWithContracts};
 
 pub(crate) fn requires(mode: ContractMode, attr: TokenStream, toks: TokenStream) -> TokenStream {
     let ty = ContractType::Requires;
 
-    let func: ItemFn = syn::parse_quote!(#toks);
+    let func: ItemFn = match syn::parse2(toks.clone()) {
+        Ok(func) => func,
+        Err(err) => return emit_error(err, toks),
+    };
 
     let f = FuncWithContracts::new_with_initial_contract(func, ty, mode, attr);
 

--- a/tests/ui/fail/description_must_be_last.stderr
+++ b/tests/ui/fail/description_must_be_last.stderr
@@ -1,7 +1,5 @@
-error[E0600]: cannot apply unary operator `!` to type `&'static str`
+error: contract description must be the last argument
  --> tests/ui/fail/description_must_be_last.rs:3:12
   |
 3 | #[requires("x must be positive", x > 0)]
-  |            ^^^^^^^^^^^^^^^^^^^^ cannot apply unary operator `!`
-  |
-  = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+  |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/fail/invalid_predicate_syntax.rs
+++ b/tests/ui/fail/invalid_predicate_syntax.rs
@@ -1,0 +1,10 @@
+use contracts::requires;
+
+#[requires(x >)]
+fn checked(x: i32) -> i32 {
+    x
+}
+
+fn main() {
+    let _ = checked(1);
+}

--- a/tests/ui/fail/invalid_predicate_syntax.stderr
+++ b/tests/ui/fail/invalid_predicate_syntax.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, expected an expression
+ --> tests/ui/fail/invalid_predicate_syntax.rs:3:1
+  |
+3 | #[requires(x >)]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `requires` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fail/invariant_on_struct.stderr
+++ b/tests/ui/fail/invariant_on_struct.stderr
@@ -1,13 +1,7 @@
-error: custom attribute panicked
- --> tests/ui/fail/invariant_on_struct.rs:3:1
+error: the #[invariant] attribute only works on functions and impl blocks
+ --> tests/ui/fail/invariant_on_struct.rs:4:1
   |
-3 | #[invariant(self.value > 0)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: message: not implemented: The #[invariant] attribute only works on functions and impl-blocks.
-
-error[E0422]: cannot find struct, variant or union type `Positive` in this scope
- --> tests/ui/fail/invariant_on_struct.rs:9:13
-  |
-9 |     let _ = Positive { value: 1 };
-  |             ^^^^^^^^ not found in this scope
+4 | / struct Positive {
+5 | |     value: i32,
+6 | | }
+  | |_^

--- a/tests/ui/fail/requires_on_struct.stderr
+++ b/tests/ui/fail/requires_on_struct.stderr
@@ -1,13 +1,5 @@
-error: custom attribute panicked
- --> tests/ui/fail/requires_on_struct.rs:3:1
+error: expected `fn`
+ --> tests/ui/fail/requires_on_struct.rs:4:1
   |
-3 | #[requires(true)]
-  | ^^^^^^^^^^^^^^^^^
-  |
-  = help: message: expected `fn`
-
-error[E0425]: cannot find value `NotAFunction` in this scope
- --> tests/ui/fail/requires_on_struct.rs:7:13
-  |
-7 |     let _ = NotAFunction;
-  |             ^^^^^^^^^^^^ not found in this scope
+4 | struct NotAFunction;
+  | ^^^^^^


### PR DESCRIPTION
## Summary

- replace proc-macro panics for invalid contract targets with spanned compiler diagnostics
- report misplaced contract descriptions directly
- cover malformed predicate syntax with an MSRV-gated UI regression test
- centralize compile-error emission while retaining original item tokens to avoid secondary errors

This addresses #3 as part of a broader cleanup of contract macro diagnostics.

## Root cause

Some macro entry points used infallible parsing or explicit panics, while other invalid inputs reached later generated code and produced indirect diagnostics.

## Validation

- `cargo +1.77.0 test --locked --test ui`
- `just clippy`
- `just test`
