### PR TITLE
Reject always false contract predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Update `syn` requirement to `3`.
 - Minimum supported Rust version (MSRV) is now 1.77.
+- Reject contract predicates that are the literal `false` at compile time.
 
 ## 0.6.7
 

--- a/src/implementation/parse.rs
+++ b/src/implementation/parse.rs
@@ -42,7 +42,28 @@ pub(crate) fn parse_attributes(
         segments_stream.pop();
     }
 
+    for cond in &mut conds {
+        error_on_false_literal(cond);
+    }
+
     (conds, segments_stream, desc)
+}
+
+fn error_on_false_literal(expr: &mut Expr) {
+    let Expr::Lit(ExprLit {
+        lit: Lit::Bool(lit),
+        ..
+    }) = expr
+    else {
+        return;
+    };
+
+    if lit.value {
+        return;
+    }
+
+    let err = syn::Error::new_spanned(&*expr, "contract predicate is always false");
+    *expr = Expr::Verbatim(err.into_compile_error());
 }
 
 // This function rewrites a list of TokenTrees so that the "pseudooperator" for

--- a/tests/ui/fail/always_false_predicate.rs
+++ b/tests/ui/fail/always_false_predicate.rs
@@ -1,0 +1,8 @@
+use contracts::ensures;
+
+#[ensures(false)]
+fn checked() {}
+
+fn main() {
+    checked();
+}

--- a/tests/ui/fail/always_false_predicate.stderr
+++ b/tests/ui/fail/always_false_predicate.stderr
@@ -1,0 +1,5 @@
+error: contract predicate is always false
+ --> tests/ui/fail/always_false_predicate.rs:3:11
+  |
+3 | #[ensures(false)]
+  |           ^^^^^


### PR DESCRIPTION
## Summary

- detect direct literal `false` contract predicates during attribute parsing
- emit a spanned `syn::Error` directly as compile-error tokens
- add an MSRV-gated trybuild fixture for the diagnostic

Closes #26.

## Validation

- `cargo +1.77.0 test --locked --test ui`
- `just clippy`
- `just test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract predicates that are always `false` are now rejected at compile time.
  * Compiler diagnostics identify the invalid predicate and highlight its location.

* **Tests**
  * Added coverage to verify compile-time rejection of always-false contract predicates.

* **Documentation**
  * Updated the changelog to document this validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->