### PR TITLE
ci: automate releases with release-plz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+
+      - name: release-plz
+        uses: MarcoIeni/release-plz-action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        id: release-plz
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Bump changelog versions
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/bump-changelogs '${{ steps.release-plz.outputs.pr }}'
+
+      - name: Update release notes
+        if: ${{ steps.release-plz.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/update-release-notes '${{ steps.release-plz.outputs.releases }}'

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,8 @@
+[workspace]
+changelog_update = false
+dependencies_update = false
+pr_draft = true
+pr_labels = ["release"]
+publish_all_features = true
+git_tag_name = "{{ package }}-v{{ version }}"
+git_release_name = "{{ package }}: v{{ version }}"

--- a/scripts/bump-changelogs
+++ b/scripts/bump-changelogs
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# Updates changelog versions indicated by release-plz.
+
+set -eEuo pipefail
+
+WORKSPACE_METADATA="$(cargo metadata --format-version=1 --no-deps)"
+
+function package_dir_for() {
+    local package_name="$1"
+    local manifest_path
+
+    manifest_path="$(
+        echo "$WORKSPACE_METADATA" \
+            | jq -r --arg package_name "$package_name" '.packages[] | select(.name == $package_name) | .manifest_path' \
+            | head -n 1
+    )"
+
+    if [[ -z "$manifest_path" || "$manifest_path" == "null" ]]; then
+        echo "Could not determine package directory for $package_name" >&2
+        return 1
+    fi
+
+    dirname "$manifest_path"
+}
+
+function bump_changelog_version() {
+    local package_dir="$1"
+    local version="$2"
+
+    local changelog_file="${package_dir}/CHANGELOG.md"
+    local readme_file="${package_dir}/README.md"
+    local unreleased_line
+    local next_heading_line
+    local previous_version
+    local change_chunk_file
+    local line_count
+
+    if [[ ! -f "$changelog_file" ]]; then
+        echo "Skipping ${package_dir}: no CHANGELOG.md"
+        return 0
+    fi
+
+    if awk -v version="$version" '$0 == "## " version { found = 1 } END { exit !found }' "$changelog_file"; then
+        echo "Skipping ${changelog_file}: already contains ${version}"
+        return 0
+    fi
+
+    unreleased_line="$(awk '/^## Unreleased$/ { print NR; exit }' "$changelog_file")"
+    if [[ -z "$unreleased_line" ]]; then
+        echo "Skipping ${changelog_file}: no '## Unreleased' heading"
+        return 0
+    fi
+
+    next_heading_line="$(
+        awk -v start="$unreleased_line" 'NR > start && /^## / { print NR; exit }' "$changelog_file"
+    )"
+    if [[ -z "$next_heading_line" ]]; then
+        echo "Skipping ${changelog_file}: no version headings found after '## Unreleased'"
+        return 0
+    fi
+
+    previous_version="$(sed -n "${next_heading_line}s/^## //p" "$changelog_file")"
+    change_chunk_file="$(mktemp)"
+    line_count="$(wc -l < "$changelog_file" | awk '{ print $1 }')"
+
+    echo "${changelog_file} -> ${version}"
+
+    sed -n "$((unreleased_line + 1)),$((next_heading_line - 1))p" "$changelog_file" \
+        | awk '
+            {
+                lines[NR] = $0
+            }
+            END {
+                first = 1
+                while (first <= NR && lines[first] ~ /^[[:space:]]*$/) {
+                    first++
+                }
+
+                last = NR
+                while (last >= first && lines[last] ~ /^[[:space:]]*$/) {
+                    last--
+                }
+
+                for (i = first; i <= last; i++) {
+                    print lines[i]
+                }
+            }
+        ' >"$change_chunk_file"
+
+    if [[ "$(wc -w "$change_chunk_file" | awk '{ print $1 }')" == "0" ]]; then
+        printf '%s\n' "- No significant changes since \`${previous_version}\`." >"$change_chunk_file"
+    fi
+
+    (
+        sed -n "1,${unreleased_line}p" "$changelog_file"
+        echo
+        echo "## $version"
+        echo
+        sed -n '1,$p' "$change_chunk_file"
+        echo
+        sed -n "${next_heading_line},${line_count}p" "$changelog_file"
+    ) >"$changelog_file.bak"
+
+    mv "$changelog_file.bak" "$changelog_file"
+    rm -f "$change_chunk_file"
+
+    if [[ -f "$readme_file" && -n "$previous_version" ]]; then
+        sed -i.bak -E "s#([=/])${previous_version}([/)])#\\1${version}\\2#g" "$readme_file"
+        rm -f "${readme_file}.bak"
+    fi
+}
+
+RELEASE_PLZ_PR_JSON="$1"
+PR_NUMBER="$(echo "$RELEASE_PLZ_PR_JSON" | jq -r '.number')"
+
+if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
+    gh pr checkout "$PR_NUMBER"
+    WORKSPACE_METADATA="$(cargo metadata --format-version=1 --no-deps)"
+fi
+
+specs="$(echo "$RELEASE_PLZ_PR_JSON" | jq -r '.releases[] | "\(.package_name):\(.version)"')"
+
+for spec in $specs; do
+    name="$(echo "$spec" | cut -d: -f1)"
+    version="$(echo "$spec" | cut -d: -f2)"
+    package_dir="$(package_dir_for "$name")"
+
+    bump_changelog_version "$package_dir" "$version"
+done
+
+if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
+    git add --all
+
+    if ! git diff --cached --quiet; then
+        git commit -m "docs: update changelog versions"
+        git push
+    fi
+fi

--- a/scripts/update-release-notes
+++ b/scripts/update-release-notes
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Updates GitHub release notes from crate changelogs.
+
+set -eEuo pipefail
+
+WORKSPACE_METADATA="$(cargo metadata --format-version=1 --no-deps)"
+
+function package_dir_for() {
+    local package_name="$1"
+    local manifest_path
+
+    manifest_path="$(
+        echo "$WORKSPACE_METADATA" \
+            | jq -r --arg package_name "$package_name" '.packages[] | select(.name == $package_name) | .manifest_path' \
+            | head -n 1
+    )"
+
+    if [[ -z "$manifest_path" || "$manifest_path" == "null" ]]; then
+        echo "Could not determine package directory for $package_name" >&2
+        return 1
+    fi
+
+    dirname "$manifest_path"
+}
+
+function update_release_notes() {
+    local package_dir="$1"
+    local version="$2"
+    local tag="$3"
+    local changelog_file="${package_dir}/CHANGELOG.md"
+
+    if [[ ! -f "$changelog_file" ]]; then
+        echo "Skipping ${tag}: no ${changelog_file}"
+        return 0
+    fi
+
+    echo "Updating ${tag} using ${changelog_file}"
+
+    local notes
+    notes="$(
+        awk -v version="$version" '
+            $0 == "## " version {
+                in_section = 1
+                next
+            }
+
+            in_section && /^## / {
+                exit
+            }
+
+            in_section {
+                lines[++count] = $0
+            }
+
+            END {
+                first = 1
+                while (first <= count && lines[first] ~ /^[[:space:]]*$/) {
+                    first++
+                }
+
+                last = count
+                while (last >= first && lines[last] ~ /^[[:space:]]*$/) {
+                    last--
+                }
+
+                for (i = first; i <= last; i++) {
+                    print lines[i]
+                }
+            }
+        ' "$changelog_file"
+    )"
+
+    if [[ -z "${notes//[[:space:]]/}" ]]; then
+        notes="- No significant changes since the previous release."
+    fi
+
+    gh release edit "$tag" --notes="$notes"
+}
+
+RELEASE_PLZ_RELEASES_JSON="$1"
+
+specs="$(echo "$RELEASE_PLZ_RELEASES_JSON" | jq -r '.[] | "\(.package_name):\(.version):\(.tag)"')"
+
+for spec in $specs; do
+    name="$(echo "$spec" | cut -d: -f1)"
+    version="$(echo "$spec" | cut -d: -f2)"
+    tag="$(echo "$spec" | cut -d: -f3)"
+    package_dir="$(package_dir_for "$name")"
+
+    update_release_notes "$package_dir" "$version" "$tag"
+done


### PR DESCRIPTION
## Summary

- run release-plz automatically after pushes to `main`
- authenticate crate publication with crates.io trusted publishing
- create draft release PRs while preserving the existing `contracts-v<version>` tag format
- rerun the required MSRV and stable tests when a release PR is marked ready for review
- promote the manually maintained `Unreleased` changelog section and use it for GitHub release notes

## Impact

Merging this enables release-plz to prepare version-bump PRs and publish crates and GitHub releases when those PRs are merged. The workflow follows the current release setup used by the other robjtede and x52dev Rust libraries.

## Validation

- `nix develop -c just check`
- `nix develop -c just clippy`
- `cargo package --all-features --allow-dirty`
- `bash -n scripts/bump-changelogs scripts/update-release-notes`
- isolated changelog promotion test from `0.6.7` to `0.6.8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing for changes merged into the main branch.
  * Added automatic changelog version updates and GitHub release note generation.
  * Release drafts are created with standardized labels, tags, and version names.

* **CI**
  * Pull request checks now run for explicitly defined pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->