### PR TITLE
Use shared Rust Just module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784633661,
-        "narHash": "sha256-eOrF1y0svdniEnjIuuvkzOv6z/ltBepYjApINcDY1Xg=",
+        "lastModified": 1785501466,
+        "narHash": "sha256-EmBn1w7+V9l1P4XqFLSZDVOxMtMIIGxUrJawlrvaO5U=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "5e898b3d4b5bb9801964488d6ab4a6ed445c1809",
+        "rev": "7f726782d3870c1d11a9480ebeb9a34a693d4a17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,13 @@
   outputs = inputs @ { flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      perSystem = { pkgs, config, inputs', system, lib, ... }:
-        let
-          x52just = inputs'.x52.packages.x52-just;
-        in
-        {
+      imports = [ inputs.x52.flakeModules.default ];
+
+      perSystem = { pkgs, config, inputs', system, lib, ... }: {
           formatter = pkgs.nixpkgs-fmt;
 
           devShells.default = pkgs.mkShell {
             buildInputs = [
-              x52just
               inputs'.x52.packages.x52-release-tools
             ];
 
@@ -36,10 +33,7 @@
               pkgs.pkgsBuildHost.libiconv
             ];
 
-            shellHook = ''
-              mkdir -p .toolchain
-              cp ${x52just}/*.just .toolchain/
-            '';
+            shellHook = config.x52.justRust.shellHook;
           };
         };
     };


### PR DESCRIPTION
## Summary

- point the `x52` flake input at `x52dev/nix` main
- import the shared flake-parts module
- replace the local `.toolchain` copy hook with `config.x52.justRust.shellHook`

## Relationship

This sample uses the shared module from [x52dev/nix](https://github.com/x52dev/nix).

## Validation

- `nix develop -c just --list`
- verified `.toolchain/rust.just` is a symlink
- `nix develop -c just check`
- `nix flake check --no-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment configuration to use the x52-provided Rust shell integration.
  * Removed redundant local package and setup handling from the development shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->