### PR TITLE
ci: simplify Nix setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Install Rust (${{ matrix.toolchain.name }})
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -56,6 +51,8 @@ jobs:
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Downgrade for MSRV
         if: matrix.toolchain.name == 'msrv'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,13 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -33,6 +28,8 @@ jobs:
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-      - name: Install Determinate Nix
+      - name: Install Nix
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
 
       - name: Bump changelog versions
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,15 @@
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
           formatter = pkgs.nixpkgs-fmt;
 
+          devShells.ci = pkgs.mkShell {
+            packages = [ pkgs.just ];
+            shellHook = config.x52.justRust.shellHook;
+          };
+
+          devShells.ci-release = pkgs.mkShell {
+            packages = [ inputs'.x52.packages.x52-release-tools ];
+          };
+
           devShells.default = pkgs.mkShell {
             buildInputs = [
               inputs'.x52.packages.x52-release-tools


### PR DESCRIPTION
## Summary

- install Nix with `nix-quick-install-action`
- remove the FlakeHub cache from CI, coverage, and release
- keep `nix-develop` separate
- use a focused `.#ci` shell for test/coverage and `.#ci-release` for release tooling
- keep the full default development shell unchanged

## Why

The latest CI baseline showed the cache post-step taking 73s for stable tests and 56s for MSRV tests. The stable job took 2m13s overall, while its test command took 5s. The release baseline also spent 14s in the cache post-step for a 1s changelog operation.

The focused shells retain only the capabilities each workflow needs: the shared Just shell hook for CI and the x52 release tools for release.

## Validation

- `nix develop .#ci -c just --list`
- `nix develop .#ci-release -c command -v x52-bump-changelogs`
- `nix develop .#ci-release -c command -v x52-update-release-notes`
- `nix flake check --no-build --all-systems`

The release and coverage workflows run only after pushes to `main`; the PR CI workflow validates the quick installer path directly.
