### PR TITLE
ci: add zizmor security lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,18 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: nix
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     versioning-strategy: lockfile-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   read_msrv:
     name: Read MSRV
-    uses: actions-rust-lang/msrv/.github/workflows/msrv.yml@main
+    uses: actions-rust-lang/msrv/.github/workflows/msrv.yml@2e4effc4a4a9437253f7f659990d4ac5ec9c7854 # main
 
   test:
     needs: read_msrv

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,8 @@ jobs:
     name: Coverage
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,3 +91,17 @@ jobs:
 
       - name: Audit check
         run: cargo deny --all-features check advisories
+
+  zizmor:
+    name: GitHub Actions Security
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0


### PR DESCRIPTION
Adds a pinned zizmor security-lint job to the existing lint workflow.

Also fixes the current audit findings: Dependabot cooldowns, checkout credential persistence, and a mutable reusable workflow reference.

Validation:

- `zizmor v1.29.0 --offline /workspace` — no findings to report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved the security of automated build, test, coverage, and release workflows.
  * Added automated checks to identify potential workflow security issues.
  * Reduced the risk associated with mutable workflow references and persisted credentials.

* **Chores**
  * Added a short stabilization period before selected dependency updates are applied, helping reduce unexpected build or release disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->