### PR TITLE
fix(ci): retain release git credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0


### PR DESCRIPTION
Keeps checkout credentials available for the release job so x52-bump-changelogs can check out and push the release PR.

The job already has scoped contents: write and pull-requests: write permissions.

Validation: zizmor v1.29.0 offline scan with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to retain checkout credentials during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->